### PR TITLE
use goimports-compatible ordering of imports

### DIFF
--- a/internal/fetch/jobDescription_test.go
+++ b/internal/fetch/jobDescription_test.go
@@ -1,9 +1,10 @@
 package fetch
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func Test_parseJobDescription(t *testing.T) {

--- a/internal/fetch/lastSuccessfulMeta.go
+++ b/internal/fetch/lastSuccessfulMeta.go
@@ -2,9 +2,10 @@ package fetch
 
 import (
 	"fmt"
-	"github.com/tidwall/gjson"
 	"io/ioutil"
 	"net/http"
+
+	"github.com/tidwall/gjson"
 )
 
 type LastSuccessfulMetaRequest struct {

--- a/internal/fetch/lastSuccessfulMeta_test.go
+++ b/internal/fetch/lastSuccessfulMeta_test.go
@@ -1,13 +1,14 @@
 package fetch
 
 import (
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 )
 
 const (

--- a/meta.go
+++ b/meta.go
@@ -5,8 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/screwdriver-cd/meta-cli/internal/fetch"
-	"github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"os"
@@ -16,6 +14,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/screwdriver-cd/meta-cli/internal/fetch"
+	"github.com/sirupsen/logrus"
 
 	"gopkg.in/urfave/cli.v1"
 )

--- a/meta_test.go
+++ b/meta_test.go
@@ -2,11 +2,12 @@ package main
 
 import (
 	"bytes"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const testFile = "meta"


### PR DESCRIPTION
use goimports [1] compatible ordering of imports to avoid future "spurious" changes when someone with goimports integrated in the editor changes something else in the file.

[1] https://godoc.org/golang.org/x/tools/cmd/goimports