### PR TITLE
reorder imports to be goimports-compatible

### DIFF
--- a/internal/fetch/jobDescription_test.go
+++ b/internal/fetch/jobDescription_test.go
@@ -1,8 +1,9 @@
 package fetch
 
 import (
-	"github.com/stretchr/testify/suite"
 	"testing"
+
+	"github.com/stretchr/testify/suite"
 )
 
 type JobDescriptionSuite struct {

--- a/internal/fetch/lastSuccessfulMeta.go
+++ b/internal/fetch/lastSuccessfulMeta.go
@@ -2,10 +2,10 @@ package fetch
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 
+	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
 )
 

--- a/internal/fetch/lastSuccessfulMeta_test.go
+++ b/internal/fetch/lastSuccessfulMeta_test.go
@@ -1,7 +1,6 @@
 package fetch
 
 import (
-	"github.com/stretchr/testify/suite"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -10,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
 )
 
 const (

--- a/meta_test.go
+++ b/meta_test.go
@@ -1,11 +1,6 @@
 package main
 
 import (
-	"github.com/screwdriver-cd/meta-cli/internal/fetch"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"github.com/stretchr/testify/suite"
-	"github.com/termie/go-shutil"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -13,6 +8,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/screwdriver-cd/meta-cli/internal/fetch"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+	"github.com/termie/go-shutil"
 )
 
 const (


### PR DESCRIPTION
PR reorders imports to be compatible with `goimports` - https://godoc.org/golang.org/x/tools/cmd/goimports, to avoid future spurious changes on saving code.